### PR TITLE
cancel drag if mouse position becomes unavailable

### DIFF
--- a/examples/complex.rs
+++ b/examples/complex.rs
@@ -4,7 +4,7 @@ use iced::widget::{
 };
 use iced::{Center, Element, Fill, Task, Theme};
 
-use dragking::{DragEvent, DropPosition};
+use dragking::DragEvent;
 
 pub fn main() -> iced::Result {
     iced::application("iced — Draggable Widgets", App::update, App::view)
@@ -116,31 +116,16 @@ impl App {
             Message::SwitchMode(mode) => {
                 self.mode = mode;
             }
-            Message::Reorder(event) => match event {
-                DragEvent::Dropped {
+            Message::Reorder(event) => {
+                if let DragEvent::Dropped {
                     index,
                     target_index,
-                    drop_position,
-                } => match drop_position {
-                    DropPosition::Before | DropPosition::After => {
-                        if target_index != index && target_index != index + 1 {
-                            let item = self.widgets.remove(index);
-                            let insert_index = if index < target_index {
-                                target_index - 1
-                            } else {
-                                target_index
-                            };
-                            self.widgets.insert(insert_index, item);
-                        }
-                    }
-                    DropPosition::Swap => {
-                        if target_index != index {
-                            self.widgets.swap(index, target_index);
-                        }
-                    }
-                },
-                _ => {}
-            },
+                } = event
+                {
+                    let item = self.widgets.remove(index);
+                    self.widgets.insert(target_index, item);
+                }
+            }
             Message::SliderChanged(value) => {
                 self.slider_value = value;
             }

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -2,7 +2,7 @@ use iced::widget::{column, container, pick_list, row, text};
 use iced::Length::Fill;
 use iced::{Center, Element, Task, Theme};
 
-use dragking::{DragEvent, DropPosition};
+use dragking::DragEvent;
 
 pub fn main() -> iced::Result {
     iced::application("iced — Draggable Widgets", App::update, App::view)
@@ -63,29 +63,10 @@ impl App {
                     DragEvent::Dropped {
                         index,
                         target_index,
-                        drop_position,
                     } => {
-                        // Update self.elements based on index, target_index, drop_position
-                        match drop_position {
-                            DropPosition::Before | DropPosition::After => {
-                                if target_index != index
-                                    && target_index != index + 1
-                                {
-                                    let item = self.elements.remove(index);
-                                    let insert_index = if index < target_index {
-                                        target_index - 1
-                                    } else {
-                                        target_index
-                                    };
-                                    self.elements.insert(insert_index, item);
-                                }
-                            }
-                            DropPosition::Swap => {
-                                if target_index != index {
-                                    self.elements.swap(index, target_index);
-                                }
-                            }
-                        }
+                        // Update self.elements based on index and target_index
+                        let item = self.elements.remove(index);
+                        self.elements.insert(target_index, item);
                     }
                     DragEvent::Canceled { .. } => {
                         // Optionally handle cancel event

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -109,11 +109,9 @@ impl App {
                 .spacing(5)
                 .on_drag(Message::Reorder)
                 // For the row example only, show a totally custom Style
-                .style(|theme| dragking::row::Style {
+                .style(|_| dragking::row::Style {
                     scale: 1.5,
-                    moved_item_overlay: iced::Color::BLACK
-                        .scale_alpha(0.75)
-                        .into(),
+                    moved_item_overlay: iced::Color::BLACK.scale_alpha(0.75),
                     ghost_background: iced::color![170, 0, 0]
                         .scale_alpha(0.25)
                         .into(),
@@ -122,7 +120,6 @@ impl App {
                         width: 0.0,
                         radius: 5.0.into(),
                     },
-                    ..dragking::row::default(theme)
                 })
                 .align_y(Center)
                 .into(),

--- a/src/column.rs
+++ b/src/column.rs
@@ -256,30 +256,27 @@ where
         &self,
         cursor_position: Point,
         layout: Layout<'_>,
-        dragged_index: usize,
     ) -> usize {
+        let bounds = layout.bounds();
         let cursor_y = cursor_position.y;
+
+        if cursor_y < bounds.y {
+            // Cursor is above all children
+            return 0;
+        }
 
         for (i, child_layout) in layout.children().enumerate() {
             let bounds = child_layout.bounds();
             let y = bounds.y;
             let height = bounds.height;
 
-            if cursor_y >= y && cursor_y <= y + height {
+            if cursor_y <= y + height {
                 return i;
             }
         }
 
-        if cursor_y < layout.position().y {
-            // Cursor is above all children
-            0
-        } else if cursor_y > layout.position().y + layout.bounds().height {
-            // Cursor is below all children
-            self.children.len() - 1
-        } else {
-            // Cursor isn't over any children
-            dragged_index
-        }
+        // Cursor is below all children
+        self.children.len() - 1
     }
 }
 
@@ -531,11 +528,8 @@ where
                             // Allocate animation slots just in case
                             animations.with_capacity(self.children.len());
 
-                            let target_index = self.compute_target_index(
-                                cursor_position,
-                                layout,
-                                index,
-                            );
+                            let target_index = self
+                                .compute_target_index(cursor_position, layout);
 
                             // Calculate height of the dragged item
                             let drag_height = if let Some(child_layout) =
@@ -618,7 +612,6 @@ where
                                 let target_index = self.compute_target_index(
                                     cursor_position,
                                     layout,
-                                    *index,
                                 );
 
                                 let drag_height = if let Some(child_layout) =
@@ -760,7 +753,7 @@ where
                 // Determine the target index based on cursor position
                 let target_index = if cursor.position().is_some() {
                     let target_index =
-                        self.compute_target_index(*last_cursor, layout, *index);
+                        self.compute_target_index(*last_cursor, layout);
                     target_index.min(child_count - 1)
                 } else {
                     *index
@@ -872,7 +865,7 @@ where
                 // Draw a ghost of the dragged item in its would-be position
                 // Get the target index based on current cursor position
                 let target_index =
-                    self.compute_target_index(*last_cursor, layout, *index);
+                    self.compute_target_index(*last_cursor, layout);
 
                 // Instead of using direction to decide signs, we need to use the
                 // target vs. current index relationship

--- a/src/column.rs
+++ b/src/column.rs
@@ -34,7 +34,7 @@ use iced::{
     Pixels, Point, Rectangle, Size, Theme, Vector,
 };
 
-use crate::{Action, DragEvent, DropPosition, ItemAnimations};
+use crate::{Action, DragEvent, ItemAnimations};
 
 pub fn column<'a, Message, Theme, Renderer>(
     children: impl IntoIterator<Item = Element<'a, Message, Theme, Renderer>>,
@@ -257,7 +257,7 @@ where
         cursor_position: Point,
         layout: Layout<'_>,
         dragged_index: usize,
-    ) -> (usize, DropPosition) {
+    ) -> usize {
         let cursor_y = cursor_position.y;
 
         for (i, child_layout) in layout.children().enumerate() {
@@ -266,33 +266,20 @@ where
             let height = bounds.height;
 
             if cursor_y >= y && cursor_y <= y + height {
-                if i == dragged_index {
-                    // Cursor is over the dragged item itself
-                    return (i, DropPosition::Swap);
-                }
-
-                let thickness = height / 4.0;
-                let top_threshold = y + thickness;
-                let bottom_threshold = y + height - thickness;
-
-                if cursor_y < top_threshold {
-                    // Near the top edge - insert above
-                    return (i, DropPosition::Before);
-                } else if cursor_y > bottom_threshold {
-                    // Near the bottom edge - insert below
-                    return (i + 1, DropPosition::After);
-                } else {
-                    // Middle area - swap
-                    return (i, DropPosition::Swap);
-                }
-            } else if cursor_y < y {
-                // Cursor is above this child
-                return (i, DropPosition::Before);
+                return i;
             }
         }
 
-        // Cursor is below all children
-        (self.children.len(), DropPosition::After)
+        if cursor_y < layout.position().y {
+            // Cursor is above all children
+            0
+        } else if cursor_y > layout.position().y + layout.bounds().height {
+            // Cursor is below all children
+            self.children.len() - 1
+        } else {
+            // Cursor isn't over any children
+            dragged_index
+        }
     }
 }
 
@@ -544,7 +531,7 @@ where
                             // Allocate animation slots just in case
                             animations.with_capacity(self.children.len());
 
-                            let (target_index, _) = self.compute_target_index(
+                            let target_index = self.compute_target_index(
                                 cursor_position,
                                 layout,
                                 index,
@@ -568,36 +555,24 @@ where
                                     continue;
                                 }
 
-                                let target_offset = match target_index
-                                    .cmp(&index)
-                                {
-                                    std::cmp::Ordering::Less
-                                        if i >= target_index && i < index =>
-                                    {
-                                        drag_height
-                                    }
-                                    std::cmp::Ordering::Greater
-                                        if i > index && i <= target_index =>
-                                    {
-                                        -drag_height
-                                    }
-                                    _ => 0.0,
-                                };
+                                let target_offset =
+                                    match target_index.cmp(&index) {
+                                        std::cmp::Ordering::Less
+                                            if (target_index..index)
+                                                .contains(&i) =>
+                                        {
+                                            drag_height
+                                        }
+                                        std::cmp::Ordering::Greater
+                                            if (index + 1..=target_index)
+                                                .contains(&i) =>
+                                        {
+                                            -drag_height
+                                        }
+                                        _ => 0.0,
+                                    };
 
-                                // Only update animations for items that need to move
-                                if target_offset != 0.0 {
-                                    if (target_offset
-                                        - animations.offsets[i].value())
-                                    .abs()
-                                        > 1.0
-                                    {
-                                        animations.offsets[i]
-                                            .go_mut(target_offset);
-                                    }
-                                } else if animations.offsets[i].value() != 0.0 {
-                                    // Return to normal position if previously moved
-                                    animations.offsets[i].go_mut(0.0);
-                                }
+                                animations.offsets[i].go_mut(target_offset);
                             }
 
                             *action = Action::Dragging {
@@ -640,12 +615,11 @@ where
                         if let Some(cursor_position) = cursor.position() {
                             let bounds = layout.bounds();
                             if bounds.contains(cursor_position) {
-                                let (target_index, drop_position) = self
-                                    .compute_target_index(
-                                        cursor_position,
-                                        layout,
-                                        *index,
-                                    );
+                                let target_index = self.compute_target_index(
+                                    cursor_position,
+                                    layout,
+                                    *index,
+                                );
 
                                 let drag_height = if let Some(child_layout) =
                                     layout.children().nth(*index)
@@ -656,42 +630,33 @@ where
                                 };
 
                                 for i in 0..animations.offsets.len() {
+                                    let target_offset = match target_index
+                                        .cmp(index)
+                                    {
+                                        std::cmp::Ordering::Less
+                                            if (target_index..*index)
+                                                .contains(&i) =>
+                                        {
+                                            drag_height
+                                        }
+                                        std::cmp::Ordering::Greater
+                                            if (*index + 1..=target_index)
+                                                .contains(&i) =>
+                                        {
+                                            -drag_height
+                                        }
+                                        _ => 0.0,
+                                    };
+
                                     if i == *index {
                                         // Reset the scale of the dragged item immediately
                                         // for a snappier feel when dropping
                                         animations.offsets[i] =
-                                            Animation::new(0.0);
+                                            Animation::new(target_offset);
                                     } else {
-                                        let offset = match target_index
-                                            .cmp(index)
-                                        {
-                                            std::cmp::Ordering::Less
-                                                if i >= target_index
-                                                    && i < *index =>
-                                            {
-                                                drag_height
-                                            }
-                                            std::cmp::Ordering::Greater
-                                                if i > *index
-                                                    && i <= target_index =>
-                                            {
-                                                -drag_height
-                                            }
-                                            _ => 0.0,
-                                        };
-
                                         // Update animation target for each item
-                                        if offset != 0.0 {
-                                            animations.offsets[i].go_mut(0.0);
-                                        } else {
-                                            let current_value =
-                                                animations.offsets[i].value();
-
-                                            if current_value != 0.0 {
-                                                animations.offsets[i]
-                                                    .go_mut(0.0);
-                                            }
-                                        }
+                                        animations.offsets[i]
+                                            .go_mut(target_offset);
                                     }
                                 }
 
@@ -700,7 +665,6 @@ where
                                         DragEvent::Dropped {
                                             index: *index,
                                             target_index,
-                                            drop_position,
                                         },
                                     ));
                                     shell.capture_event();
@@ -795,7 +759,7 @@ where
 
                 // Determine the target index based on cursor position
                 let target_index = if cursor.position().is_some() {
-                    let (target_index, _) =
+                    let target_index =
                         self.compute_target_index(*last_cursor, layout, *index);
                     target_index.min(child_count - 1)
                 } else {
@@ -907,7 +871,7 @@ where
                 }
                 // Draw a ghost of the dragged item in its would-be position
                 // Get the target index based on current cursor position
-                let (target_index, _) =
+                let target_index =
                     self.compute_target_index(*last_cursor, layout, *index);
 
                 // Instead of using direction to decide signs, we need to use the

--- a/src/column.rs
+++ b/src/column.rs
@@ -26,7 +26,6 @@ use iced::advanced::layout::{self, Layout};
 use iced::advanced::widget::{tree, Operation, Tree, Widget};
 use iced::advanced::{overlay, renderer, Clipboard, Shell};
 use iced::alignment::{self, Alignment};
-use iced::animation::Easing;
 use iced::time::Instant;
 use iced::{mouse, Transformation};
 use iced::{
@@ -320,13 +319,6 @@ where
         let mut animations = ItemAnimations::default();
         animations.with_capacity(self.children.len());
 
-        // Set up animations with appropriate duration and easing
-        for i in 0..animations.offsets.len() {
-            animations.offsets[i] = Animation::new(0.0)
-                .easing(Easing::EaseOutExpo)
-                .duration(std::time::Duration::from_millis(250));
-        }
-
         tree::State::new(Action::Idle {
             now: Some(Instant::now()),
             animations,
@@ -458,32 +450,26 @@ where
                 if let Some(cursor_position) =
                     cursor.position_over(layout.bounds())
                 {
-                    for (index, child_layout) in layout.children().enumerate() {
-                        if child_layout.bounds().contains(cursor_position) {
-                            // Get animations from previous state
-                            let animations = match action {
-                                Action::Idle { animations, .. } => animations,
-                                Action::Picking { animations, .. } => {
-                                    animations
-                                }
-                                Action::Dragging { animations, .. } => {
-                                    animations
-                                }
-                            };
+                    // Get animations from previous state
+                    let animations = match action {
+                        Action::Idle { animations, .. } => animations,
+                        Action::Picking { animations, .. } => animations,
+                        Action::Dragging { animations, .. } => animations,
+                    };
+                    animations.zero();
 
-                            let mut animations = std::mem::take(animations);
-                            animations.offsets[index] = Animation::new(0.0);
-                            *action = Action::Picking {
-                                index,
-                                origin: cursor_position,
-                                now: Instant::now(),
-                                animations,
-                            };
-                            shell.capture_event();
-                            shell.request_redraw();
-                            return;
-                        }
-                    }
+                    let index =
+                        self.compute_target_index(cursor_position, layout);
+
+                    *action = Action::Picking {
+                        index,
+                        origin: cursor_position,
+                        now: Instant::now(),
+                        animations: std::mem::take(animations),
+                    };
+
+                    shell.capture_event();
+                    shell.request_redraw();
                 }
             }
             Event::Mouse(mouse::Event::CursorMoved { .. }) => {

--- a/src/column.rs
+++ b/src/column.rs
@@ -487,7 +487,7 @@ where
                                 }
                             };
 
-                            let mut animations = animations.clone();
+                            let mut animations = std::mem::take(animations);
                             animations.offsets[index] = Animation::new(0.0);
                             *action = Action::Picking {
                                 index,
@@ -508,7 +508,7 @@ where
                         index,
                         origin,
                         now,
-                        ref animations,
+                        ref mut animations,
                     } => {
                         if let Some(cursor_position) = cursor.position() {
                             if cursor_position.distance(origin)
@@ -520,7 +520,7 @@ where
                                     origin,
                                     last_cursor: cursor_position,
                                     now,
-                                    animations: animations.clone(),
+                                    animations: std::mem::take(animations),
                                 };
                                 shell.request_redraw();
                                 if let Some(on_reorder) = &self.on_drag {
@@ -529,7 +529,6 @@ where
                                     ));
                                 }
                                 shell.capture_event();
-                                return;
                             }
                         }
                     }
@@ -606,10 +605,20 @@ where
                                 origin,
                                 index,
                                 now,
-                                animations: animations.clone(),
+                                animations: std::mem::take(animations),
                             };
                             shell.capture_event();
-                            return;
+                        } else {
+                            if let Some(on_reorder) = &self.on_drag {
+                                shell.publish(on_reorder(
+                                    DragEvent::Canceled { index },
+                                ));
+                            }
+
+                            *action = Action::Idle {
+                                now: Some(now),
+                                animations: std::mem::take(animations),
+                            };
                         }
                     }
                     _ => {}
@@ -707,7 +716,7 @@ where
                         // Transition to Idle state with animations
                         *action = Action::Idle {
                             now: Some(current_now),
-                            animations: animations.clone(),
+                            animations: std::mem::take(animations),
                         };
                     }
                     Action::Picking {
@@ -716,7 +725,7 @@ where
                         // Did not move enough to start dragging
                         *action = Action::Idle {
                             now: Some(*now),
-                            animations: animations.clone(),
+                            animations: std::mem::take(animations),
                         };
                     }
                     _ => {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,24 +56,9 @@ impl ItemAnimations {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq)]
-pub enum DropPosition {
-    Before,
-    Swap,
-    After,
-}
-
 #[derive(Debug, Clone)]
 pub enum DragEvent {
-    Picked {
-        index: usize,
-    },
-    Dropped {
-        index: usize,
-        target_index: usize,
-        drop_position: DropPosition,
-    },
-    Canceled {
-        index: usize,
-    },
+    Picked { index: usize },
+    Dropped { index: usize, target_index: usize },
+    Canceled { index: usize },
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,7 +56,7 @@ impl ItemAnimations {
     }
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub enum DropPosition {
     Before,
     Swap,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,6 +45,12 @@ pub(crate) struct ItemAnimations {
 }
 
 impl ItemAnimations {
+    pub fn zero(&mut self) {
+        for animation in &mut self.offsets {
+            *animation = Animation::new(0.0);
+        }
+    }
+
     pub fn is_animating(&self, now: Instant) -> bool {
         self.offsets.iter().any(|anim| anim.is_animating(now))
     }

--- a/src/row.rs
+++ b/src/row.rs
@@ -34,7 +34,7 @@ use iced::{
     Pixels, Point, Rectangle, Size, Theme, Vector,
 };
 
-use crate::{Action, DragEvent, DropPosition, ItemAnimations};
+use crate::{Action, DragEvent, ItemAnimations};
 
 pub fn row<'a, Message, Theme, Renderer>(
     children: impl IntoIterator<Item = Element<'a, Message, Theme, Renderer>>,
@@ -256,7 +256,7 @@ where
         cursor_position: Point,
         layout: Layout<'_>,
         dragged_index: usize,
-    ) -> (usize, DropPosition) {
+    ) -> usize {
         let cursor_x = cursor_position.x;
 
         for (i, child_layout) in layout.children().enumerate() {
@@ -265,33 +265,20 @@ where
             let width = bounds.width;
 
             if cursor_x >= x && cursor_x <= x + width {
-                if i == dragged_index {
-                    // Cursor is over the dragged item itself
-                    return (i, DropPosition::Swap);
-                }
-
-                let thickness = width / 4.0;
-                let left_threshold = x + thickness;
-                let right_threshold = x + width - thickness;
-
-                if cursor_x < left_threshold {
-                    // Near the left edge - insert before
-                    return (i, DropPosition::Before);
-                } else if cursor_x > right_threshold {
-                    // Near the right edge - insert after
-                    return (i + 1, DropPosition::After);
-                } else {
-                    // Middle area - swap
-                    return (i, DropPosition::Swap);
-                }
-            } else if cursor_x < x {
-                // Cursor is before this child
-                return (i, DropPosition::Before);
+                return i;
             }
         }
 
-        // Cursor is after all children
-        (self.children.len(), DropPosition::After)
+        if cursor_x < layout.position().x {
+            // Cursor is before all children
+            0
+        } else if cursor_x > layout.position().x + layout.bounds().width {
+            // Cursor is after all children
+            self.children.len() - 1
+        } else {
+            // Cursor isn't over any children
+            dragged_index
+        }
     }
 }
 
@@ -541,7 +528,7 @@ where
                             // Allocate animation slots just in case
                             animations.with_capacity(self.children.len());
 
-                            let (target_index, _) = self.compute_target_index(
+                            let target_index = self.compute_target_index(
                                 cursor_position,
                                 layout,
                                 index,
@@ -564,36 +551,24 @@ where
                                     continue;
                                 }
 
-                                let target_offset = match target_index
-                                    .cmp(&index)
-                                {
-                                    std::cmp::Ordering::Less
-                                        if i >= target_index && i < index =>
-                                    {
-                                        drag_width
-                                    }
-                                    std::cmp::Ordering::Greater
-                                        if i > index && i <= target_index =>
-                                    {
-                                        -drag_width
-                                    }
-                                    _ => 0.0,
-                                };
+                                let target_offset =
+                                    match target_index.cmp(&index) {
+                                        std::cmp::Ordering::Less
+                                            if (target_index..index)
+                                                .contains(&i) =>
+                                        {
+                                            drag_width
+                                        }
+                                        std::cmp::Ordering::Greater
+                                            if (index + 1..=target_index)
+                                                .contains(&i) =>
+                                        {
+                                            -drag_width
+                                        }
+                                        _ => 0.0,
+                                    };
 
-                                // Only update animations for items that need to move
-                                if target_offset != 0.0 {
-                                    if (target_offset
-                                        - animations.offsets[i].value())
-                                    .abs()
-                                        > 1.0
-                                    {
-                                        animations.offsets[i]
-                                            .go_mut(target_offset);
-                                    }
-                                } else if animations.offsets[i].value() != 0.0 {
-                                    // Return to normal position if previously moved
-                                    animations.offsets[i].go_mut(0.0);
-                                }
+                                animations.offsets[i].go_mut(target_offset);
                             }
 
                             *action = Action::Dragging {
@@ -636,12 +611,11 @@ where
                         if let Some(cursor_position) = cursor.position() {
                             let bounds = layout.bounds();
                             if bounds.contains(cursor_position) {
-                                let (target_index, drop_position) = self
-                                    .compute_target_index(
-                                        cursor_position,
-                                        layout,
-                                        *index,
-                                    );
+                                let target_index = self.compute_target_index(
+                                    cursor_position,
+                                    layout,
+                                    *index,
+                                );
 
                                 let drag_width = if let Some(child_layout) =
                                     layout.children().nth(*index)
@@ -652,42 +626,33 @@ where
                                 };
 
                                 for i in 0..animations.offsets.len() {
+                                    let target_offset = match target_index
+                                        .cmp(index)
+                                    {
+                                        std::cmp::Ordering::Less
+                                            if (target_index..*index)
+                                                .contains(&i) =>
+                                        {
+                                            drag_width
+                                        }
+                                        std::cmp::Ordering::Greater
+                                            if (*index + 1..=target_index)
+                                                .contains(&i) =>
+                                        {
+                                            -drag_width
+                                        }
+                                        _ => 0.0,
+                                    };
+
                                     if i == *index {
                                         // Reset the scale of the dragged item immediately
                                         // for a snappier feel when dropping
                                         animations.offsets[i] =
-                                            Animation::new(0.0);
+                                            Animation::new(target_offset);
                                     } else {
-                                        let offset = match target_index
-                                            .cmp(index)
-                                        {
-                                            std::cmp::Ordering::Less
-                                                if i >= target_index
-                                                    && i < *index =>
-                                            {
-                                                drag_width
-                                            }
-                                            std::cmp::Ordering::Greater
-                                                if i > *index
-                                                    && i <= target_index =>
-                                            {
-                                                -drag_width
-                                            }
-                                            _ => 0.0,
-                                        };
-
                                         // Update animation target for each item
-                                        if offset != 0.0 {
-                                            animations.offsets[i].go_mut(0.0);
-                                        } else {
-                                            let current_value =
-                                                animations.offsets[i].value();
-
-                                            if current_value != 0.0 {
-                                                animations.offsets[i]
-                                                    .go_mut(0.0);
-                                            }
-                                        }
+                                        animations.offsets[i]
+                                            .go_mut(target_offset);
                                     }
                                 }
 
@@ -696,7 +661,6 @@ where
                                         DragEvent::Dropped {
                                             index: *index,
                                             target_index,
-                                            drop_position,
                                         },
                                     ));
                                     shell.capture_event();
@@ -785,7 +749,7 @@ where
 
                 // Determine the target index based on cursor position
                 let target_index = if cursor.position().is_some() {
-                    let (target_index, _) =
+                    let target_index =
                         self.compute_target_index(*last_cursor, layout, *index);
                     target_index.min(child_count - 1)
                 } else {
@@ -903,7 +867,7 @@ where
                 }
                 // Draw a ghost of the dragged item in its would-be position
                 // Get the target index based on current cursor position
-                let (target_index, _) =
+                let target_index =
                     self.compute_target_index(*last_cursor, layout, *index);
 
                 // Instead of using direction to decide signs, we need to use the

--- a/src/row.rs
+++ b/src/row.rs
@@ -484,7 +484,7 @@ where
                                 }
                             };
 
-                            let mut animations = animations.clone();
+                            let mut animations = std::mem::take(animations);
                             animations.offsets[index] = Animation::new(0.0);
                             *action = Action::Picking {
                                 index,
@@ -505,7 +505,7 @@ where
                         index,
                         origin,
                         now,
-                        ref animations,
+                        ref mut animations,
                     } => {
                         if let Some(cursor_position) = cursor.position() {
                             if cursor_position.distance(origin)
@@ -517,7 +517,7 @@ where
                                     origin,
                                     last_cursor: cursor_position,
                                     now,
-                                    animations: animations.clone(),
+                                    animations: std::mem::take(animations),
                                 };
                                 shell.request_redraw();
                                 if let Some(on_reorder) = &self.on_drag {
@@ -526,7 +526,6 @@ where
                                     ));
                                 }
                                 shell.capture_event();
-                                return;
                             }
                         }
                     }
@@ -602,10 +601,20 @@ where
                                 origin,
                                 index,
                                 now,
-                                animations: animations.clone(),
+                                animations: std::mem::take(animations),
                             };
                             shell.capture_event();
-                            return;
+                        } else {
+                            if let Some(on_reorder) = &self.on_drag {
+                                shell.publish(on_reorder(
+                                    DragEvent::Canceled { index },
+                                ));
+                            }
+
+                            *action = Action::Idle {
+                                now: Some(now),
+                                animations: std::mem::take(animations),
+                            };
                         }
                     }
                     _ => {}
@@ -703,7 +712,7 @@ where
                         // Transition to Idle state with animations
                         *action = Action::Idle {
                             now: Some(current_now),
-                            animations: animations.clone(),
+                            animations: std::mem::take(animations),
                         };
                     }
                     Action::Picking {
@@ -712,7 +721,7 @@ where
                         // Did not move enough to start dragging
                         *action = Action::Idle {
                             now: Some(*now),
-                            animations: animations.clone(),
+                            animations: std::mem::take(animations),
                         };
                     }
                     _ => {}

--- a/src/row.rs
+++ b/src/row.rs
@@ -255,30 +255,27 @@ where
         &self,
         cursor_position: Point,
         layout: Layout<'_>,
-        dragged_index: usize,
     ) -> usize {
+        let bounds = layout.bounds();
         let cursor_x = cursor_position.x;
+
+        if cursor_x < bounds.x {
+            // Cursor is before all children
+            return 0;
+        }
 
         for (i, child_layout) in layout.children().enumerate() {
             let bounds = child_layout.bounds();
             let x = bounds.x;
             let width = bounds.width;
 
-            if cursor_x >= x && cursor_x <= x + width {
+            if cursor_x <= x + width {
                 return i;
             }
         }
 
-        if cursor_x < layout.position().x {
-            // Cursor is before all children
-            0
-        } else if cursor_x > layout.position().x + layout.bounds().width {
-            // Cursor is after all children
-            self.children.len() - 1
-        } else {
-            // Cursor isn't over any children
-            dragged_index
-        }
+        // Cursor is after all children
+        self.children.len() - 1
     }
 }
 
@@ -528,11 +525,8 @@ where
                             // Allocate animation slots just in case
                             animations.with_capacity(self.children.len());
 
-                            let target_index = self.compute_target_index(
-                                cursor_position,
-                                layout,
-                                index,
-                            );
+                            let target_index = self
+                                .compute_target_index(cursor_position, layout);
                             // Calculate width of the dragged item
                             let drag_width = if let Some(child_layout) =
                                 layout.children().nth(index)
@@ -614,7 +608,6 @@ where
                                 let target_index = self.compute_target_index(
                                     cursor_position,
                                     layout,
-                                    *index,
                                 );
 
                                 let drag_width = if let Some(child_layout) =
@@ -750,7 +743,7 @@ where
                 // Determine the target index based on cursor position
                 let target_index = if cursor.position().is_some() {
                     let target_index =
-                        self.compute_target_index(*last_cursor, layout, *index);
+                        self.compute_target_index(*last_cursor, layout);
                     target_index.min(child_count - 1)
                 } else {
                     *index
@@ -868,7 +861,7 @@ where
                 // Draw a ghost of the dragged item in its would-be position
                 // Get the target index based on current cursor position
                 let target_index =
-                    self.compute_target_index(*last_cursor, layout, *index);
+                    self.compute_target_index(*last_cursor, layout);
 
                 // Instead of using direction to decide signs, we need to use the
                 // target vs. current index relationship

--- a/src/row.rs
+++ b/src/row.rs
@@ -26,7 +26,6 @@ use iced::advanced::layout::{self, Layout};
 use iced::advanced::widget::{tree, Operation, Tree, Widget};
 use iced::advanced::{overlay, renderer, Clipboard, Shell};
 use iced::alignment::{self, Alignment};
-use iced::animation::Easing;
 use iced::time::Instant;
 use iced::{mouse, Transformation};
 use iced::{
@@ -319,13 +318,6 @@ where
         let mut animations = ItemAnimations::default();
         animations.with_capacity(self.children.len());
 
-        // Set up animations with appropriate duration and easing
-        for i in 0..animations.offsets.len() {
-            animations.offsets[i] = Animation::new(0.0)
-                .easing(Easing::EaseOutExpo)
-                .duration(std::time::Duration::from_millis(250));
-        }
-
         tree::State::new(Action::Idle {
             now: Some(Instant::now()),
             animations,
@@ -455,32 +447,26 @@ where
                 if let Some(cursor_position) =
                     cursor.position_over(layout.bounds())
                 {
-                    for (index, child_layout) in layout.children().enumerate() {
-                        if child_layout.bounds().contains(cursor_position) {
-                            // Get animations from previous state
-                            let animations = match action {
-                                Action::Idle { animations, .. } => animations,
-                                Action::Picking { animations, .. } => {
-                                    animations
-                                }
-                                Action::Dragging { animations, .. } => {
-                                    animations
-                                }
-                            };
+                    // Get animations from previous state
+                    let animations = match action {
+                        Action::Idle { animations, .. } => animations,
+                        Action::Picking { animations, .. } => animations,
+                        Action::Dragging { animations, .. } => animations,
+                    };
+                    animations.zero();
 
-                            let mut animations = std::mem::take(animations);
-                            animations.offsets[index] = Animation::new(0.0);
-                            *action = Action::Picking {
-                                index,
-                                origin: cursor_position,
-                                now: Instant::now(),
-                                animations,
-                            };
-                            shell.capture_event();
-                            shell.request_redraw();
-                            return;
-                        }
-                    }
+                    let index =
+                        self.compute_target_index(cursor_position, layout);
+
+                    *action = Action::Picking {
+                        index,
+                        origin: cursor_position,
+                        now: Instant::now(),
+                        animations: std::mem::take(animations),
+                    };
+
+                    shell.capture_event();
+                    shell.request_redraw();
                 }
             }
             Event::Mouse(mouse::Event::CursorMoved { .. }) => {


### PR DESCRIPTION
What does this PR change?

1. cancel the dragging operation if the cursor position ever becomes unavailable (e.g. leaving the bounds of a scrollable)
2. clean up animations to remove flickering everywhere
3. remove `DropPosition`, since it felt unintuitive and wasn't being reflected properly in animations