### PR TITLE
chore: update iced to the latest version and update the Rust edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT"
 repository = "https://github.com/airstrike/dragking"
 
 [dependencies]
-iced = { git = "https://github.com/iced-rs/iced.git", branch = "master", default-features = false, features = [
+iced = { git = "https://github.com/iced-rs/iced.git", default-features = false, features = [
     "advanced",
     "wgpu",
     "tokio",
@@ -16,7 +16,7 @@ iced = { git = "https://github.com/iced-rs/iced.git", branch = "master", default
 ] }
 
 [dev-dependencies]
-iced = { git = "https://github.com/iced-rs/iced.git", branch = "master", default-features = false, features = [
+iced = { git = "https://github.com/iced-rs/iced.git", default-features = false, features = [
     "advanced",
     "wgpu",
     "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "dragking"
-version = "0.1.0"
-edition = "2021"
+version = "0.1.1"
+edition = "2024"
 authors = ["Andy Terra <spam@andyterra.com>"]
 description = "A very simple implementation of drag and drop for `iced`'s `Row` and `Column` widgets"
 license = "MIT"
@@ -11,12 +11,13 @@ repository = "https://github.com/airstrike/dragking"
 iced = { git = "https://github.com/iced-rs/iced.git", branch = "master", default-features = false, features = [
     "advanced",
     "wgpu",
+    "tokio",
+
 ] }
 
 [dev-dependencies]
 iced = { git = "https://github.com/iced-rs/iced.git", branch = "master", default-features = false, features = [
     "advanced",
-    "lazy",
     "wgpu",
     "tokio",
 ] }

--- a/examples/complex.rs
+++ b/examples/complex.rs
@@ -142,7 +142,7 @@ impl App {
         }
     }
 
-    fn view(&self) -> Element<Message> {
+    fn view(&self) -> Element<'_, Message> {
         let items = || {
             self.widgets.iter().map(|widget| match widget {
                 WidgetType::Slider => Element::from(
@@ -249,7 +249,6 @@ impl App {
 
 fn handle(_theme: &Theme) -> rule::Style {
     rule::Style {
-        width: 5,
         radius: 0.into(),
         color: iced::Color::BLACK.scale_alpha(0.2),
         fill_mode: rule::FillMode::Full,

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -1,5 +1,5 @@
-use iced::widget::{column, container, pick_list, row, text};
 use iced::Length::Fill;
+use iced::widget::{column, container, pick_list, row, text};
 use iced::{Center, Element, Task, Theme};
 
 use dragking::DragEvent;
@@ -77,7 +77,7 @@ impl App {
         }
     }
 
-    fn view(&self) -> Element<Message> {
+    fn view(&self) -> Element<'_, Message> {
         let items = self.elements.iter().map(|label| pickme(label));
         let drag: Element<'_, Message> = match self.mode {
             Mode::Column => dragking::column(items.collect::<Vec<_>>())

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,3 +1,3 @@
 max_width = 80
-edition = "2021"
+edition = "2024"
 indent_style = "Block"

--- a/src/column.rs
+++ b/src/column.rs
@@ -329,8 +329,8 @@ where
         self.children.iter().map(Tree::new).collect()
     }
 
-    fn diff(&mut self, tree: &mut Tree) {
-        tree.diff_children(&mut self.children);
+    fn diff(&self, tree: &mut Tree) {
+        tree.diff_children(&self.children);
 
         let action = tree.state.downcast_mut::<Action>();
 

--- a/src/column.rs
+++ b/src/column.rs
@@ -23,15 +23,15 @@
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 use iced::advanced::layout::{self, Layout};
-use iced::advanced::widget::{tree, Operation, Tree, Widget};
-use iced::advanced::{overlay, renderer, Clipboard, Shell};
+use iced::advanced::widget::{Operation, Tree, Widget, tree};
+use iced::advanced::{Clipboard, Shell, overlay, renderer};
 use iced::alignment::{self, Alignment};
 use iced::time::Instant;
-use iced::{mouse, Transformation};
 use iced::{
     Animation, Background, Border, Color, Element, Event, Length, Padding,
     Pixels, Point, Rectangle, Size, Theme, Vector,
 };
+use iced::{Transformation, mouse};
 
 use crate::{Action, DragEvent, ItemAnimations};
 
@@ -329,8 +329,8 @@ where
         self.children.iter().map(Tree::new).collect()
     }
 
-    fn diff(&self, tree: &mut Tree) {
-        tree.diff_children(&self.children);
+    fn diff(&mut self, tree: &mut Tree) {
+        tree.diff_children(&mut self.children);
 
         let action = tree.state.downcast_mut::<Action>();
 
@@ -352,7 +352,7 @@ where
     }
 
     fn layout(
-        &self,
+        &mut self,
         tree: &mut Tree,
         renderer: &Renderer,
         limits: &layout::Limits,
@@ -368,13 +368,13 @@ where
             self.padding,
             self.spacing,
             self.align,
-            &self.children,
+            &mut self.children,
             &mut tree.children,
         )
     }
 
     fn operate(
-        &self,
+        &mut self,
         tree: &mut Tree,
         layout: Layout<'_>,
         renderer: &Renderer,
@@ -382,12 +382,12 @@ where
     ) {
         operation.container(None, layout.bounds(), &mut |operation| {
             self.children
-                .iter()
+                .iter_mut()
                 .zip(&mut tree.children)
                 .zip(layout.children())
                 .for_each(|((child, state), layout)| {
                     child
-                        .as_widget()
+                        .as_widget_mut()
                         .operate(state, layout, renderer, operation);
                 });
         });
@@ -585,7 +585,7 @@ where
                 match action {
                     Action::Dragging {
                         index,
-                        ref mut animations,
+                        animations,
                         now,
                         ..
                     } => {

--- a/src/row.rs
+++ b/src/row.rs
@@ -23,15 +23,15 @@
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 use iced::advanced::layout::{self, Layout};
-use iced::advanced::widget::{tree, Operation, Tree, Widget};
-use iced::advanced::{overlay, renderer, Clipboard, Shell};
+use iced::advanced::widget::{Operation, Tree, Widget, tree};
+use iced::advanced::{Clipboard, Shell, overlay, renderer};
 use iced::alignment::{self, Alignment};
 use iced::time::Instant;
-use iced::{mouse, Transformation};
 use iced::{
     Animation, Background, Border, Color, Element, Event, Length, Padding,
     Pixels, Point, Rectangle, Size, Theme, Vector,
 };
+use iced::{Transformation, mouse};
 
 use crate::{Action, DragEvent, ItemAnimations};
 
@@ -328,8 +328,8 @@ where
         self.children.iter().map(Tree::new).collect()
     }
 
-    fn diff(&self, tree: &mut Tree) {
-        tree.diff_children(&self.children);
+    fn diff(&mut self, tree: &mut Tree) {
+        tree.diff_children(&mut self.children);
 
         let action = tree.state.downcast_mut::<Action>();
 
@@ -351,7 +351,7 @@ where
     }
 
     fn layout(
-        &self,
+        &mut self,
         tree: &mut Tree,
         renderer: &Renderer,
         limits: &layout::Limits,
@@ -365,13 +365,13 @@ where
             self.padding,
             self.spacing,
             self.align,
-            &self.children,
+            &mut self.children,
             &mut tree.children,
         )
     }
 
     fn operate(
-        &self,
+        &mut self,
         tree: &mut Tree,
         layout: Layout<'_>,
         renderer: &Renderer,
@@ -379,12 +379,12 @@ where
     ) {
         operation.container(None, layout.bounds(), &mut |operation| {
             self.children
-                .iter()
+                .iter_mut()
                 .zip(&mut tree.children)
                 .zip(layout.children())
                 .for_each(|((child, state), layout)| {
                     child
-                        .as_widget()
+                        .as_widget_mut()
                         .operate(state, layout, renderer, operation);
                 });
         });
@@ -581,7 +581,7 @@ where
                 match action {
                     Action::Dragging {
                         index,
-                        ref mut animations,
+                        animations,
                         now,
                         ..
                     } => {
@@ -1020,7 +1020,7 @@ where
         self.row.children()
     }
 
-    fn diff(&self, tree: &mut Tree) {
+    fn diff(&mut self, tree: &mut Tree) {
         self.row.diff(tree);
     }
 
@@ -1029,7 +1029,7 @@ where
     }
 
     fn layout(
-        &self,
+        &mut self,
         tree: &mut Tree,
         renderer: &Renderer,
         limits: &layout::Limits,
@@ -1070,8 +1070,8 @@ where
             }
         };
 
-        for (i, child) in self.row.children.iter().enumerate() {
-            let node = child.as_widget().layout(
+        for (i, child) in self.row.children.iter_mut().enumerate() {
+            let node = child.as_widget_mut().layout(
                 &mut tree.children[i],
                 renderer,
                 &limits,
@@ -1114,7 +1114,7 @@ where
     }
 
     fn operate(
-        &self,
+        &mut self,
         tree: &mut Tree,
         layout: Layout<'_>,
         renderer: &Renderer,

--- a/src/row.rs
+++ b/src/row.rs
@@ -328,8 +328,8 @@ where
         self.children.iter().map(Tree::new).collect()
     }
 
-    fn diff(&mut self, tree: &mut Tree) {
-        tree.diff_children(&mut self.children);
+    fn diff(&self, tree: &mut Tree) {
+        tree.diff_children(&self.children);
 
         let action = tree.state.downcast_mut::<Action>();
 
@@ -1020,7 +1020,7 @@ where
         self.row.children()
     }
 
-    fn diff(&mut self, tree: &mut Tree) {
+    fn diff(&self, tree: &mut Tree) {
         self.row.diff(tree);
     }
 


### PR DESCRIPTION
This PR updates:
- The rust edition to the latest one ( 2024 );
- Iced to make it work on the latest version ( namely due to https://github.com/iced-rs/iced/pull/3038 );
- Ups the versioning number.

I've also removed `lazy` from the features list due to https://github.com/iced-rs/iced/commit/199a18951504ce43686138130be0cbab9748503e and added `tokio`, since it wouldn't compile otherwise.